### PR TITLE
Add support for IDv3 and operator v2 APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ The UID 2 Project is subject to Tech Lab IPR’s Policy and is managed by the IA
 
 ## Install
 
-1. add reference to uid2-client-1.0.0-jar-with-dependencies.jar generated from build & package setup in your project
+1. add reference to uid2-client-2.0.0-jar-with-dependencies.jar generated from build & package setup in your project
 
 2. install the library locally and reference via maven
 
 ```
-    mvn install:install-file -Dfile="./target/uid2-client-1.0.0-jar-with-dependencies.jar" -DgroupId="com.uid2" -DartifactId="uid2-client" -Dpackaging=jar -Dversion="1.0.0"
+    mvn install:install-file -Dfile="./target/uid2-client-2.0.0-jar-with-dependencies.jar" -DgroupId="com.uid2" -DartifactId="uid2-client" -Dpackaging=jar -Dversion="2.0.0"
 ```
 
 this will install the jar into your local .m2 repository, you can set your desired target repo with `-DlocalRepositoryPath=path-to-specific-local-repo`
@@ -25,7 +25,7 @@ then on your maven project's pom.xml, add
         <dependency>
             <groupId>com.uid2</groupId>
             <artifactId>uid2-client</artifactId>
-            <version>1.0.0</version>
+            <version>2.0.0</version>
         </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-client</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>UID2 Client</description>

--- a/src/main/java/com/uid2/client/DecryptionResponse.java
+++ b/src/main/java/com/uid2/client/DecryptionResponse.java
@@ -59,4 +59,8 @@ public class DecryptionResponse {
     public static DecryptionResponse makeError(DecryptionStatus status) {
         return new DecryptionResponse(status, null, Instant.MIN, null);
     }
+
+    public static DecryptionResponse makeError(DecryptionStatus status, Instant established, Integer siteId) {
+        return new DecryptionResponse(status, null, established, siteId);
+    }
 }

--- a/src/main/java/com/uid2/client/DecryptionStatus.java
+++ b/src/main/java/com/uid2/client/DecryptionStatus.java
@@ -32,4 +32,5 @@ public enum DecryptionStatus {
     KEYS_NOT_SYNCED,
     VERSION_NOT_SUPPORTED,
     INVALID_PAYLOAD_TYPE,
+    INVALID_IDENTITY_SCOPE,
 }

--- a/src/main/java/com/uid2/client/EUIDClientFactory.java
+++ b/src/main/java/com/uid2/client/EUIDClientFactory.java
@@ -23,8 +23,8 @@
 
 package com.uid2.client;
 
-public class UID2ClientFactory {
+public class EUIDClientFactory {
     public static IUID2Client create(String endpoint, String authKey, String secretKey) {
-        return new UID2Client(endpoint, authKey, secretKey, IdentityScope.UID2);
+        return new UID2Client(endpoint, authKey, secretKey, IdentityScope.EUID);
     }
 }

--- a/src/main/java/com/uid2/client/IdentityScope.java
+++ b/src/main/java/com/uid2/client/IdentityScope.java
@@ -23,8 +23,19 @@
 
 package com.uid2.client;
 
-public class UID2ClientFactory {
-    public static IUID2Client create(String endpoint, String authKey, String secretKey) {
-        return new UID2Client(endpoint, authKey, secretKey, IdentityScope.UID2);
+public enum IdentityScope {
+    UID2(0),
+    EUID(1);
+
+    public final int value;
+
+    IdentityScope(int value) { this.value = value; }
+
+    public static IdentityScope fromValue(int value) {
+        switch (value) {
+            case 0: return UID2;
+            case 1: return EUID;
+            default: throw new IllegalArgumentException();
+        }
     }
 }

--- a/src/main/java/com/uid2/client/IdentityType.java
+++ b/src/main/java/com/uid2/client/IdentityType.java
@@ -23,8 +23,18 @@
 
 package com.uid2.client;
 
-public class UID2ClientFactory {
-    public static IUID2Client create(String endpoint, String authKey, String secretKey) {
-        return new UID2Client(endpoint, authKey, secretKey, IdentityScope.UID2);
+public enum IdentityType {
+    Email(0), Phone(1);
+
+    public final int value;
+
+    IdentityType(int value) { this.value = value; }
+
+    public static IdentityType fromValue(int value) {
+        switch (value) {
+            case 0: return Email;
+            case 1: return Phone;
+            default: throw new IllegalArgumentException();
+        }
     }
 }

--- a/src/main/java/com/uid2/client/PayloadType.java
+++ b/src/main/java/com/uid2/client/PayloadType.java
@@ -1,7 +1,8 @@
 package com.uid2.client;
 
 enum PayloadType {
-    ENCRYPTED_DATA(128);
+    ENCRYPTED_DATA(128),
+    ENCRYPTED_DATA_V3(96);
 
     public final int value;
     PayloadType(int value) { this.value = value; }

--- a/src/main/java/com/uid2/client/UID2Client.java
+++ b/src/main/java/com/uid2/client/UID2Client.java
@@ -23,13 +23,15 @@
 
 package com.uid2.client;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -38,23 +40,31 @@ public class UID2Client implements IUID2Client {
     private final AtomicReference<KeyContainer> container;
     private final String endpoint;
     private final String authKey;
+    private final byte[] secretKey;
+    private final IdentityScope identityScope;
 
-    public UID2Client(String endpoint, String authKey) {
+    public UID2Client(String endpoint, String authKey, String secretKey, IdentityScope identityScope) {
         this.endpoint = endpoint;
         this.authKey = authKey;
+        this.secretKey = Base64.getDecoder().decode(secretKey);
+        this.identityScope = identityScope;
         this.container = new AtomicReference<>(null);
     }
 
     @Override
     public void refresh() throws UID2ClientException {
         try {
-            URL serviceUrl = new URL(endpoint + "/v1/key/latest");
+            V2Request request = makeV2Request(Instant.now());
+            URL serviceUrl = new URL(endpoint + "/v2/key/latest");
             URLConnection conn = serviceUrl.openConnection();
             HttpURLConnection httpsConnection = (HttpURLConnection) conn;
-            httpsConnection.setRequestMethod("GET");
+            httpsConnection.setRequestMethod("POST");
             httpsConnection.setDoInput(true);
             httpsConnection.setDoOutput(true);
             httpsConnection.setRequestProperty("Authorization", "Bearer " + this.authKey);
+            try(OutputStream os = httpsConnection.getOutputStream()) {
+                os.write(request.envelope);
+            }
             int statusCode = httpsConnection.getResponseCode();
 
             if (statusCode == 401) {
@@ -64,7 +74,8 @@ public class UID2Client implements IUID2Client {
             }
 
             try {
-                this.container.set(KeyParser.parse(httpsConnection.getInputStream()));
+                byte[] response = parseV2Response(readAllBytes(httpsConnection.getInputStream()), request.nonce);
+                this.container.set(KeyParser.parse(new ByteArrayInputStream(response)));
             } catch (Exception e) {
                 throw new UID2ClientException("error while parsing json response", e);
             }
@@ -90,7 +101,7 @@ public class UID2Client implements IUID2Client {
         }
 
         try {
-            return Decryption.decrypt(Base64.getDecoder().decode(token), container, now);
+            return Decryption.decrypt(Base64.getDecoder().decode(token), container, now, this.identityScope);
         } catch (Exception e) {
             return DecryptionResponse.makeError(DecryptionStatus.INVALID_PAYLOAD);
         }
@@ -98,7 +109,7 @@ public class UID2Client implements IUID2Client {
 
     @Override
     public EncryptionDataResponse encryptData(EncryptionDataRequest request) {
-        return Decryption.encryptData(request, this.container.get());
+        return Decryption.encryptData(request, this.container.get(), this.identityScope);
     }
 
     @Override
@@ -113,9 +124,56 @@ public class UID2Client implements IUID2Client {
         }
 
         try {
-            return Decryption.decryptData(Base64.getDecoder().decode(encryptedData), container);
+            return Decryption.decryptData(Base64.getDecoder().decode(encryptedData), container, this.identityScope);
         } catch (Exception e) {
             return DecryptionDataResponse.makeError(DecryptionStatus.INVALID_PAYLOAD);
+        }
+    }
+
+    private V2Request makeV2Request(Instant now) {
+        byte[] nonce = new byte[8];
+        new SecureRandom().nextBytes(nonce);
+        ByteBuffer writer = ByteBuffer.allocate(16);
+        writer.putLong(now.toEpochMilli());
+        writer.put(nonce);
+        byte[] encrypted = Decryption.encryptGCM(writer.array(), null, this.secretKey);
+        ByteBuffer request = ByteBuffer.allocate(encrypted.length + 1);
+        request.put((byte)1); // version
+        request.put(encrypted);
+        return new V2Request(Base64.getEncoder().encode(request.array()), nonce);
+    }
+
+    private static byte[] readAllBytes(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+        int nRead;
+        byte[] data = new byte[4096];
+
+        while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+            buffer.write(data, 0, nRead);
+        }
+
+        return buffer.toByteArray();
+    }
+
+    private byte[] parseV2Response(byte[] envelope, byte[] nonce) throws IllegalStateException {
+        byte[] envelopeBytes = Base64.getDecoder().decode(envelope);
+        byte[] payload = Decryption.decryptGCM(envelopeBytes, 0, this.secretKey);
+        byte[] receivedNonce = Arrays.copyOfRange(payload, 8, 8 + nonce.length);
+        if (!Arrays.equals(receivedNonce, nonce)) {
+            throw new IllegalStateException("nonce mismatch");
+        }
+        return Arrays.copyOfRange(payload, 16, payload.length);
+    }
+
+    private static class V2Request
+    {
+        public final byte[] envelope;
+        public final byte[] nonce;
+
+        public V2Request(byte[] envelope, byte[] nonce) {
+            this.envelope = envelope;
+            this.nonce = nonce;
         }
     }
 }

--- a/src/test/java/com/uid2/client/test/DecryptionTestsV2.java
+++ b/src/test/java/com/uid2/client/test/DecryptionTestsV2.java
@@ -1,0 +1,225 @@
+// Copyright (c) 2021 The Trade Desk, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package com.uid2.client.test;
+
+import com.google.gson.stream.JsonWriter;
+import com.uid2.client.*;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import java.io.StringWriter;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Base64;
+
+public class DecryptionTestsV2 {
+
+    public static final long MASTER_KEY_ID = 164;
+    public static final long SITE_KEY_ID = 165;
+    public static final int SITE_ID = 9000;
+    public static final int[] INT_MASTER_SECRET = new int[] { 139, 37, 241, 173, 18, 92, 36, 232, 165, 168, 23, 18, 38, 195, 123, 92, 160, 136, 185, 40, 91, 173, 165, 221, 168, 16, 169, 164, 38, 139, 8, 155 };
+    public static final int[] INT_SITE_SECRET = new int[] { 32, 251, 7, 194, 132, 154, 250, 86, 202, 116, 104, 29, 131, 192, 139, 215, 48, 164, 11, 65, 226, 110, 167, 14, 108, 51, 254, 125, 65, 24, 23, 133 };
+    public static final Instant NOW = Instant.now();
+    public static final Key MASTER_KEY = new Key(MASTER_KEY_ID, -1, NOW.minus(1, ChronoUnit.DAYS), NOW, NOW.plus(1, ChronoUnit.DAYS), getMasterSecret());
+    public static final Key SITE_KEY = new Key(SITE_KEY_ID, SITE_ID, NOW.minus(10, ChronoUnit.DAYS), NOW.minus(1, ChronoUnit.DAYS), NOW.plus(1, ChronoUnit.DAYS), getSiteSecret());
+    public static final String EXAMPLE_UID = "ywsvDNINiZOVSsfkHpLpSJzXzhr6Jx9Z/4Q0+lsEUvM=";
+    private static final String CLIENT_SECRET = "ioG3wKxAokmp+rERx6A4kM/13qhyolUXIu14WN16Spo=";
+
+    @Test
+    public void smokeTest() throws Exception {
+        UID2Client client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+        client.refreshJson(keySetToJson(MASTER_KEY, SITE_KEY));
+        String advertisingToken = Base64.getEncoder().encodeToString(KeyGen.encryptV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY));
+        DecryptionResponse res = client.decrypt(advertisingToken);
+        assertEquals(EXAMPLE_UID, res.getUid());
+    }
+
+    @Test
+    public void emptyKeyContainer() throws Exception {
+        UID2Client client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+        String advertisingToken = Base64.getEncoder().encodeToString(KeyGen.encryptV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY));
+        DecryptionResponse res = client.decrypt(advertisingToken);
+        assertEquals(DecryptionStatus.NOT_INITIALIZED, res.getStatus());
+    }
+
+    @Test
+    public void expiredKeyContainer() throws Exception {
+        UID2Client client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+        String advertisingToken = Base64.getEncoder().encodeToString(KeyGen.encryptV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY));
+
+        Key masterKeyExpired = new Key(MASTER_KEY_ID, -1, NOW, NOW.minus(2, ChronoUnit.HOURS), NOW.minus(1, ChronoUnit.HOURS), getMasterSecret());
+        Key siteKeyExpired = new Key(SITE_KEY_ID, SITE_ID, NOW, NOW.minus(2, ChronoUnit.HOURS), NOW.minus(1, ChronoUnit.HOURS), getSiteSecret());
+        client.refreshJson(keySetToJson(masterKeyExpired, siteKeyExpired));
+
+        DecryptionResponse res = client.decrypt(advertisingToken);
+        assertEquals(DecryptionStatus.KEYS_NOT_SYNCED, res.getStatus());
+    }
+
+    @Test
+    public void notAuthorizedForKey() throws Exception {
+        UID2Client client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+        String advertisingToken = Base64.getEncoder().encodeToString(KeyGen.encryptV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY));
+
+        Key anotherMasterKey = new Key(MASTER_KEY_ID + SITE_KEY_ID + 1, -1, NOW, NOW, NOW.plus(1, ChronoUnit.HOURS), getMasterSecret());
+        Key anotherSiteKey = new Key(MASTER_KEY_ID + SITE_KEY_ID + 2, SITE_ID, NOW, NOW, NOW.plus(1, ChronoUnit.HOURS), getSiteSecret());
+        client.refreshJson(keySetToJson(anotherMasterKey, anotherSiteKey));
+
+        DecryptionResponse res = client.decrypt(advertisingToken);
+        assertEquals(DecryptionStatus.NOT_AUTHORIZED_FOR_KEY, res.getStatus());
+    }
+
+    @Test
+    public void invalidPayload() throws Exception {
+        UID2Client client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+        byte[] payload = KeyGen.encryptV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY);
+        String advertisingToken = Base64.getEncoder().encodeToString(Arrays.copyOfRange(payload, 0, payload.length - 1));
+
+        client.refreshJson(keySetToJson(MASTER_KEY, SITE_KEY));
+
+        DecryptionResponse res = client.decrypt(advertisingToken);
+        assertEquals(DecryptionStatus.INVALID_PAYLOAD, res.getStatus());
+    }
+
+    @Test
+    public void tokenExpiryAndCustomNow() throws Exception {
+        final Instant expiry = Instant.parse("2021-03-22T09:01:02Z");
+        final KeyGen.Params params = KeyGen.defaultParams().withTokenExpiry(expiry);
+
+        UID2Client client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+        client.refreshJson(keySetToJson(MASTER_KEY, SITE_KEY));
+        String advertisingToken = Base64.getEncoder().encodeToString(KeyGen.encryptV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY, params));
+
+        DecryptionResponse res = client.decrypt(advertisingToken, expiry.plus(1, ChronoUnit.SECONDS));
+        assertEquals(DecryptionStatus.EXPIRED_TOKEN, res.getStatus());
+
+        res = client.decrypt(advertisingToken, expiry.minus(1, ChronoUnit.SECONDS));
+        assertEquals(EXAMPLE_UID, res.getUid());
+    }
+
+    @Test
+    public void decryptData() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5, 6};
+        final Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        final String encrypted = KeyGen.encryptDataV2(data, SITE_KEY, 12345, now);
+        UID2Client client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+        client.refreshJson(keySetToJson(SITE_KEY));
+        DecryptionDataResponse decrypted = client.decryptData(encrypted);
+        assertEquals(DecryptionStatus.SUCCESS, decrypted.getStatus());
+        assertArrayEquals(data, decrypted.getDecryptedData());
+        assertEquals(now, decrypted.getEncryptedAt());
+    }
+
+    @Test
+    public void decryptDataBadPayloadType() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5, 6};
+        final String encrypted = KeyGen.encryptDataV2(data, SITE_KEY, 12345, Instant.now());
+        UID2Client client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+        client.refreshJson(keySetToJson(SITE_KEY));
+        byte[] encryptedBytes = Base64.getDecoder().decode(encrypted);
+        encryptedBytes[0] = (byte)0;
+        DecryptionDataResponse decrypted = client.decryptData(Base64.getEncoder().encodeToString(encryptedBytes));
+        assertEquals(DecryptionStatus.INVALID_PAYLOAD_TYPE, decrypted.getStatus());
+    }
+
+    @Test
+    public void decryptDataBadVersion() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5, 6};
+        final String encrypted = KeyGen.encryptDataV2(data, SITE_KEY, 12345, Instant.now());
+        UID2Client client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+        client.refreshJson(keySetToJson(SITE_KEY));
+        byte[] encryptedBytes = Base64.getDecoder().decode(encrypted);
+        encryptedBytes[1] = (byte)0;
+        DecryptionDataResponse decrypted = client.decryptData(Base64.getEncoder().encodeToString(encryptedBytes));
+        assertEquals(DecryptionStatus.VERSION_NOT_SUPPORTED, decrypted.getStatus());
+    }
+
+    @Test
+    public void decryptDataBadPayload() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5, 6};
+        final String encrypted = KeyGen.encryptDataV2(data, SITE_KEY, 12345, Instant.now());
+        UID2Client client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+        client.refreshJson(keySetToJson(SITE_KEY));
+        byte[] encryptedBytes = Base64.getDecoder().decode(encrypted);
+
+        byte[] encryptedBytesMod = new byte[encryptedBytes.length+1];
+        System.arraycopy(encryptedBytes, 0, encryptedBytesMod, 0, encryptedBytes.length);
+        DecryptionDataResponse decrypted = client.decryptData(Base64.getEncoder().encodeToString(encryptedBytesMod));
+        assertEquals(DecryptionStatus.INVALID_PAYLOAD, decrypted.getStatus());
+
+        encryptedBytesMod = new byte[encryptedBytes.length-2];
+        System.arraycopy(encryptedBytes, 0, encryptedBytesMod, 0, encryptedBytes.length-2);
+        decrypted = client.decryptData(Base64.getEncoder().encodeToString(encryptedBytesMod));
+        assertEquals(DecryptionStatus.INVALID_PAYLOAD, decrypted.getStatus());
+    }
+
+    @Test
+    public void decryptDataNoDecryptionKey() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5, 6};
+        final String encrypted = KeyGen.encryptDataV2(data, SITE_KEY, 12345, Instant.now());
+        UID2Client client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+        client.refreshJson(keySetToJson(SITE_KEY));
+        client.refreshJson(keySetToJson(MASTER_KEY));
+        DecryptionDataResponse decrypted = client.decryptData(encrypted);
+        assertEquals(DecryptionStatus.NOT_AUTHORIZED_FOR_KEY, decrypted.getStatus());
+    }
+
+    private static String keySetToJson(Key ... keys) throws Exception {
+        StringWriter sw = new StringWriter();
+        JsonWriter writer = new JsonWriter(sw);
+        writer.beginObject();
+        writer.name("body");
+        writer.beginArray();
+        for(Key k : keys) {
+            writer.beginObject();
+            writer.name("id"); writer.value(k.getId());
+            writer.name("site_id"); writer.value(k.getSiteId());
+            writer.name("created"); writer.value(k.getCreated().getEpochSecond());
+            writer.name("activates"); writer.value(k.getActivates().getEpochSecond());
+            writer.name("expires"); writer.value(k.getExpires().getEpochSecond());
+            writer.name("secret"); writer.value(Base64.getEncoder().encodeToString(k.getSecret()));
+            writer.endObject();
+        }
+        writer.endArray();
+        writer.endObject();
+        return sw.toString();
+    }
+
+    private static byte[] getMasterSecret() {
+        return intArrayToByteArray(INT_MASTER_SECRET);
+    }
+
+    private static byte[] getSiteSecret() {
+        return intArrayToByteArray(INT_SITE_SECRET);
+    }
+
+    private static byte[] intArrayToByteArray(int[] intArray) {
+        byte[] byteArray = new byte[intArray.length];
+        for (int i = 0; i < intArray.length; i++) {
+            byteArray[i] = (byte) (intArray[i] & 0xFF);
+        }
+        return byteArray;
+    }
+}

--- a/src/test/java/com/uid2/client/test/IntegrationExamples.java
+++ b/src/test/java/com/uid2/client/test/IntegrationExamples.java
@@ -30,24 +30,26 @@ import java.util.TimerTask;
 import org.junit.Test;
 
 public class IntegrationExamples {
-    private static final String TEST_ENDPOINT = "https://integ.uidapi.com";
-    private static final String TEST_API_KEY = "test-id-reader-key";
-    private static final String TEST_TOKEN = "AgAAAANzUr8B6CCM+WBKichZGU8iyDBSI83LXiXa1SW2i4LaVQPzlBtOhjoeUUc3Nv+aOPLwiVol0rnxwdNkJNgm710I4lKAp8kpjqZO6evjN6mVZalwzQA5Y4usQVEtwBkYr3V3MbYR1eI3n0Bc7/KVeanfBXUF4odpHNBEWTAL+YgSCA==";
+    private static final String TEST_ENDPOINT = "https://operator-integ.uidapi.com";
+    private static final String TEST_API_KEY = "your-api-key";
+    private static final String TEST_SECRET_KEY = "your-secret-key";
+    private static final String TEST_TOKEN = "AgAAAOl7YylgZJJ/hUsxVU7YCuXMuCAq3Muz7KaJN/miMBL/q6hgN8QY/ocy5c8d/zBvkfDMrLz+6jJvFWWHnl1u2O1mtX20/Ctft8CRwZl32b0d58fWoEhijxROd1q5DBww6+7N7ay26IttdQ+B4Rf4MTL2T/3PK9yyETae1l4v0ODd7w==";
 
     @Test // - insert your API key & test uid before enabling this test
     public void runE2E() throws Exception {
-        IUID2Client client = UID2ClientFactory.create(TEST_ENDPOINT, TEST_API_KEY);
+        IUID2Client client = UID2ClientFactory.create(TEST_ENDPOINT, TEST_API_KEY, TEST_SECRET_KEY);
         client.refresh();
         DecryptionResponse result = client.decrypt(TEST_TOKEN);
         System.out.println(result.getStatus());
         System.out.println(result.getEstablished());
+        System.out.println(result.getSiteId());
         System.out.println(result.getUid());
     }
 
     // this test works as an example for how you can perform auto refresh on this client
     @Test // - insert your API key & test uid before enabling this test
     public void runAutoRefreshWithTimer() throws Exception {
-        IUID2Client client = UID2ClientFactory.create(TEST_ENDPOINT, TEST_API_KEY);
+        IUID2Client client = UID2ClientFactory.create(TEST_ENDPOINT, TEST_API_KEY, TEST_SECRET_KEY);
         Timer timer = new Timer();
         timer.schedule(new TimerTask() {
             @Override
@@ -71,7 +73,7 @@ public class IntegrationExamples {
 
     @Test
     public void runEncryptDecryptData() throws Exception {
-        IUID2Client client = UID2ClientFactory.create(TEST_ENDPOINT, TEST_API_KEY);
+        IUID2Client client = UID2ClientFactory.create(TEST_ENDPOINT, TEST_API_KEY, TEST_SECRET_KEY);
         client.refresh();
 
         final byte[] data = "Hello World!".getBytes();

--- a/src/test/java/com/uid2/client/test/KeyGen.java
+++ b/src/test/java/com/uid2/client/test/KeyGen.java
@@ -21,24 +21,32 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
- package com.uid2.client.test;
+package com.uid2.client.test;
 
+import com.uid2.client.IdentityScope;
+import com.uid2.client.IdentityType;
 import com.uid2.client.Key;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.Random;
 
 public class KeyGen {
     public static class Params
     {
         Instant tokenExpiry = Instant.now().plus(1, ChronoUnit.HOURS);
+        public int identityScope = IdentityScope.UID2.value;
+        public int identityType = IdentityType.Email.value;
 
         public Params() {}
         public Params withTokenExpiry(Instant expiry) { tokenExpiry = expiry; return this; }
@@ -46,11 +54,11 @@ public class KeyGen {
 
     public static Params defaultParams() { return new Params(); }
 
-    public static byte[] encrypt(String uid, Key masterKey, long siteId, Key siteKey) throws Exception {
-        return encrypt(uid, masterKey, siteId, siteKey, defaultParams());
+    public static byte[] encryptV2(String uid, Key masterKey, long siteId, Key siteKey) throws Exception {
+        return encryptV2(uid, masterKey, siteId, siteKey, defaultParams());
     }
 
-    public static byte[] encrypt(String uid, Key masterKey, long siteId, Key siteKey, Params params) throws Exception {
+    public static byte[] encryptV2(String uid, Key masterKey, long siteId, Key siteKey, Params params) throws Exception {
         Random rd = new Random();
         byte[] uidBytes = uid.getBytes(StandardCharsets.UTF_8);
         ByteBuffer identityWriter = ByteBuffer.allocate(4 + 4 + uidBytes.length + 4 + 8);
@@ -82,6 +90,62 @@ public class KeyGen {
         return rootWriter.array();
     }
 
+    public static byte[] encryptV3(String uid, Key masterKey, long siteId, Key siteKey) throws Exception {
+        return encryptV3(uid, masterKey, siteId, siteKey, defaultParams());
+    }
+
+    public static byte[] encryptV3(String uid, Key masterKey, long siteId, Key siteKey, Params params) throws Exception {
+        final ByteBuffer sitePayloadWriter = ByteBuffer.allocate(128);
+
+        // publisher data
+        sitePayloadWriter.putInt((int)siteId);
+        sitePayloadWriter.putLong(0L); // publisher id
+        sitePayloadWriter.putInt(0); // client key id
+
+        // user identity data
+        sitePayloadWriter.putInt(0); // privacy bits
+        sitePayloadWriter.putLong(Instant.now().minus(1, ChronoUnit.HOURS).toEpochMilli()); // established
+        sitePayloadWriter.putLong(Instant.now().toEpochMilli()); // last refreshed
+        sitePayloadWriter.put(Base64.getDecoder().decode(uid));
+
+        final ByteBuffer masterPayloadWriter = ByteBuffer.allocate(256);
+        masterPayloadWriter.putLong(params.tokenExpiry.toEpochMilli());
+        masterPayloadWriter.putLong(Instant.now().toEpochMilli()); // token created
+
+        // operator identity data
+        masterPayloadWriter.putInt(0); // site id
+        masterPayloadWriter.put((byte)1); // operator type
+        masterPayloadWriter.putInt(0); // operator version
+        masterPayloadWriter.putInt(0); // operator key id
+        masterPayloadWriter.putInt((int)siteKey.getId());
+        masterPayloadWriter.put(encryptGCM(Arrays.copyOfRange(sitePayloadWriter.array(), 0, sitePayloadWriter.position()), siteKey.getSecret()));
+
+        final byte[] encryptedMasterPayload = encryptGCM(Arrays.copyOfRange(masterPayloadWriter.array(), 0, masterPayloadWriter.position()), masterKey.getSecret());
+        final ByteBuffer rootWriter = ByteBuffer.allocate(encryptedMasterPayload.length + 6);
+        rootWriter.put((byte)((params.identityScope << 4) | (params.identityType << 2)));
+        rootWriter.put((byte)112);
+        rootWriter.putInt((int)masterKey.getId());
+        rootWriter.put(encryptedMasterPayload);
+
+        return rootWriter.array();
+    }
+
+    public static String encryptDataV2(byte[] data, Key key, int siteId, Instant now) throws Exception {
+        final byte[] iv = new byte[16];
+        new SecureRandom().nextBytes(iv);
+        final byte[] encryptedData = encrypt(data, iv, key.getSecret());
+
+        final ByteBuffer writer = ByteBuffer.allocate(encryptedData.length + 18);
+        writer.put((byte)128);
+        writer.put((byte)1); // version
+        writer.putLong(now.toEpochMilli());
+        writer.putInt(siteId);
+        writer.putInt((int)key.getId());
+        writer.put(encryptedData);
+
+        return Base64.getEncoder().encodeToString(writer.array());
+    }
+
     private static byte[] encrypt(byte[] data, byte[] iv, byte[] secret) throws Exception {
         SecretKey key = new SecretKeySpec(secret, 0, secret.length, "AES");
         Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
@@ -91,5 +155,22 @@ public class KeyGen {
         for (int i = 0; i < 16; i++) finalized[i] = iv[i];
         for (int i = 0; i < encrypted.length; i++) finalized[16 + i] = encrypted[i];
         return finalized;
+    }
+
+    public static byte[] encryptGCM(byte[] b, byte[] secretBytes) {
+        try {
+            final SecretKey k = new SecretKeySpec(secretBytes, "AES");
+            final Cipher c = Cipher.getInstance("AES/GCM/NoPadding");
+            final byte[] iv = new byte[12];
+            new SecureRandom().nextBytes(iv);
+            GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(16 * 8, iv);
+            c.init(Cipher.ENCRYPT_MODE, k, gcmParameterSpec);
+            ByteBuffer buffer = ByteBuffer.allocate(b.length + 12 + 16);
+            buffer.put(iv);
+            buffer.put(c.doFinal(b));
+            return buffer.array();
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to Encrypt", e);
+        }
     }
 }


### PR DESCRIPTION
- switch querying keys to use v2 APIs
- switch DEP blob encryption to v3 format
- add support for decrypting v3 advertising tokens and DEP blobs
- make site id and identity established timestamp available even if advertising token is expired
- added EUID and phone number support