### PR TITLE
Made expiration timestamps public

### DIFF
--- a/src/main/java/com/uid2/client/IdentityTokens.java
+++ b/src/main/java/com/uid2/client/IdentityTokens.java
@@ -79,11 +79,20 @@ public class IdentityTokens {
 
   String getRefreshResponseKey() { return refreshResponseKey; }
 
-  Instant getIdentityExpires() { return identityExpires; } //indicates when the advertising token expires
+  /**
+   * @return Instant that indicated when the advertising token expires
+   */
+  public Instant getIdentityExpires() { return identityExpires; }
 
-  Instant getRefreshExpires() { return refreshExpires; } //indicates when the refresh token expires
+  /**
+   * @return Instant that indicates when the refresh token expires
+   */
+  public Instant getRefreshExpires() { return refreshExpires; } //indicates when the refresh token expires
 
-  Instant getRefreshFrom() { return refreshFrom; }
+  /**
+   * @return Instant that indicated when identity is due for refresh
+   */
+  public Instant getRefreshFrom() { return refreshFrom; }
 
 
   private IdentityTokens(String advertisingToken, String refreshToken, String refreshResponseKey, Instant identityExpires,


### PR DESCRIPTION
Expiration timestamps are exposed by EUID2 REST API, and we have a need to pass them along to the client.