### PR TITLE
[CVE-2022-4244] Remove maven-model as dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,6 @@
             <artifactId>okhttp</artifactId>
             <version>4.10.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>3.3.9</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Trivy has flagged a vulnerability in package `org.codehaus.plexus:plexus-utils:jar:3.0.22` 
```

┌──────────────────────────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────┐
│             Library              │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                   Title                   │
├──────────────────────────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────┤
│ org.codehaus.plexus:plexus-utils │ CVE-2022-4244 │ HIGH     │ fixed  │ 3.0.22            │ 3.0.24        │ codehaus-plexus: Directory Traversal      │
│                                  │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4244 │
└──────────────────────────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────┘
```
https://github.com/IABTechLab/uid2-client-java/actions/runs/8475000264/job/23222348106
The dependency is brought in by `org.apache.maven:maven-model:jar:3.3.9:` upgrading it to latest version fixes the issue  but I don't think its needed in our project
```
[INFO] --- dependency:3.6.0:tree (default-cli) @ uid2-client ---
[INFO] com.uid2:uid2-client:jar:4.3.2-479d2cb58f
[INFO] +- com.google.code.gson:gson:jar:2.10:compile
[INFO] +- org.junit.jupiter:junit-jupiter-engine:jar:5.9.2:test
[INFO] |  +- org.junit.platform:junit-platform-engine:jar:1.9.2:test
[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
[INFO] |  |  \- org.junit.platform:junit-platform-commons:jar:1.9.2:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-api:jar:5.9.2:test
[INFO] |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
[INFO] +- com.squareup.okhttp3:okhttp:jar:4.10.0:compile
[INFO] |  +- com.squareup.okio:okio-jvm:jar:3.0.0:compile
[INFO] |  |  +- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.5.31:compile
[INFO] |  |  |  \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.5.31:compile
[INFO] |  |  \- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.5.31:compile
[INFO] |  \- org.jetbrains.kotlin:kotlin-stdlib:jar:1.6.20:compile
[INFO] |     \- org.jetbrains:annotations:jar:13.0:compile
[INFO] \- org.apache.maven:maven-model:jar:3.3.9:compile
[INFO]    +- org.codehaus.plexus:plexus-utils:jar:3.0.22:compile
[INFO]    \- org.apache.commons:commons-lang3:jar:3.4:compile
```