### PR TITLE
Support Domain or App name check in bidstream client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.34</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,6 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.34</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/com/uid2/client/BidstreamClient.java
+++ b/src/main/java/com/uid2/client/BidstreamClient.java
@@ -9,12 +9,12 @@ public class BidstreamClient {
         tokenHelper = new TokenHelper(baseUrl, clientApiKey, base64SecretKey);
     }
 
-    public DecryptionResponse decryptTokenIntoRawUid(String token, String domainNameFromBidRequest) {
-        return tokenHelper.decrypt(token, Instant.now(), domainNameFromBidRequest, ClientType.BIDSTREAM);
+    public DecryptionResponse decryptTokenIntoRawUid(String token, String domainOrAppNameFromBidRequest) {
+        return tokenHelper.decrypt(token, Instant.now(), domainOrAppNameFromBidRequest, ClientType.BIDSTREAM);
     }
 
-    DecryptionResponse decryptTokenIntoRawUid(String token, String domainNameFromBidRequest, Instant now) {
-        return tokenHelper.decrypt(token, now, domainNameFromBidRequest, ClientType.BIDSTREAM);
+    DecryptionResponse decryptTokenIntoRawUid(String token, String domainOrAppNameFromBidRequest, Instant now) {
+        return tokenHelper.decrypt(token, now, domainOrAppNameFromBidRequest, ClientType.BIDSTREAM);
     }
 
     public RefreshResponse refresh() {

--- a/src/main/java/com/uid2/client/BidstreamClient.java
+++ b/src/main/java/com/uid2/client/BidstreamClient.java
@@ -13,7 +13,7 @@ public class BidstreamClient {
         return tokenHelper.decrypt(token, Instant.now(), domainOrAppNameFromBidRequest, ClientType.BIDSTREAM);
     }
 
-    DecryptionResponse decryptTokenIntoRawUid(String token, String domainOrAppNameFromBidRequest, Instant now) {
+    public DecryptionResponse decryptTokenIntoRawUid(String token, String domainOrAppNameFromBidRequest, Instant now) {
         return tokenHelper.decrypt(token, now, domainOrAppNameFromBidRequest, ClientType.BIDSTREAM);
     }
 

--- a/src/main/java/com/uid2/client/DecryptionStatus.java
+++ b/src/main/java/com/uid2/client/DecryptionStatus.java
@@ -47,5 +47,9 @@ public enum DecryptionStatus {
      /**
       * INVALID_TOKEN_LIFETIME: The token has invalid timestamps.
       */
-    INVALID_TOKEN_LIFETIME
+    INVALID_TOKEN_LIFETIME,
+     /**
+      * DOMAIN_OR_APP_NAME_CHECK_FAILED: The supplied domain name or app name doesn't match with the allowed names of the participant who generated this token
+      */
+    DOMAIN_OR_APP_NAME_CHECK_FAILED
 }

--- a/src/main/java/com/uid2/client/DecryptionStatus.java
+++ b/src/main/java/com/uid2/client/DecryptionStatus.java
@@ -49,7 +49,7 @@ public enum DecryptionStatus {
       */
     INVALID_TOKEN_LIFETIME,
      /**
-      * DOMAIN_OR_APP_NAME_CHECK_FAILED: The supplied domain name or app name doesn't match with the allowed names of the participant who generated this token
+      * DOMAIN_OR_APP_NAME_CHECK_FAILED: The supplied domain name or app name doesn't match with the allowed names of the site/app where this token was generated
       */
     DOMAIN_OR_APP_NAME_CHECK_FAILED
 }

--- a/src/main/java/com/uid2/client/KeyParser.java
+++ b/src/main/java/com/uid2/client/KeyParser.java
@@ -61,8 +61,33 @@ class KeyParser {
                 keys.add(key);
             }
 
-            return new KeyContainer(callerSiteId, masterKeysetId, defaultKeysetId, tokenExpirySeconds, keys, identityScope, maxBidstreamLifetimeSeconds, maxSharingLifetimeSeconds, allowClockSkewSeconds);
+            JsonArray sitesJson = body.getAsJsonArray("site_data");
+            List<Site> sites = new ArrayList<>();
+            if (!isNull(sitesJson)) {
+                for (JsonElement siteJson : sitesJson.asList()) {
+                    Site site = getSiteFromJson(siteJson.getAsJsonObject());
+                    if (site != null) {
+                        sites.add(site);
+                    }
+                }
+            }
+
+            return new KeyContainer(callerSiteId, masterKeysetId, defaultKeysetId, tokenExpirySeconds, keys, sites, identityScope, maxBidstreamLifetimeSeconds, maxSharingLifetimeSeconds, allowClockSkewSeconds);
         }
+    }
+
+    private static Site getSiteFromJson(JsonObject siteJson) {
+        int siteId = getAsInt(siteJson, "id");
+        if (siteId == 0) {
+            return null;
+        }
+        JsonArray domainOrAppNamesJArray = siteJson.getAsJsonArray("domain_names");
+        List<String> domainOrAppNames = new ArrayList<>();
+        for (int i = 0; i < domainOrAppNamesJArray.size(); ++i) {
+            domainOrAppNames.add(domainOrAppNamesJArray.get(i).getAsString());
+        }
+
+        return new Site(siteId, domainOrAppNames);
     }
 
     static private int getAsInt(JsonObject body, String memberName) {

--- a/src/main/java/com/uid2/client/KeyParser.java
+++ b/src/main/java/com/uid2/client/KeyParser.java
@@ -6,7 +6,9 @@ import java.io.InputStreamReader;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 
 class KeyParser {
@@ -82,12 +84,12 @@ class KeyParser {
             return null;
         }
         JsonArray domainOrAppNamesJArray = siteJson.getAsJsonArray("domain_names");
-        List<String> domainOrAppNames = new ArrayList<>();
+        Set<String> domainOrAppNamesSet = new HashSet<>();
         for (int i = 0; i < domainOrAppNamesJArray.size(); ++i) {
-            domainOrAppNames.add(domainOrAppNamesJArray.get(i).getAsString());
+            domainOrAppNamesSet.add(domainOrAppNamesJArray.get(i).getAsString());
         }
 
-        return new Site(siteId, domainOrAppNames);
+        return new Site(siteId, domainOrAppNamesSet);
     }
 
     static private int getAsInt(JsonObject body, String memberName) {

--- a/src/main/java/com/uid2/client/Site.java
+++ b/src/main/java/com/uid2/client/Site.java
@@ -1,0 +1,23 @@
+package com.uid2.client;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.Getter;
+
+@Getter
+public class Site {
+    private final int id;
+
+    private final Set<String> domainOrAppNames;
+
+    public Site(int id, List<String> domainOrAppNames) {
+        this.id = id;
+        this.domainOrAppNames = new HashSet<>(domainOrAppNames);
+    }
+
+    public boolean allowDomainOrAppName(String domainOrAppName) {
+        // Using streams because HashSet's contains() is case sensitive
+        return domainOrAppNames.stream().anyMatch(domainOrAppName::equalsIgnoreCase);
+    }
+}

--- a/src/main/java/com/uid2/client/Site.java
+++ b/src/main/java/com/uid2/client/Site.java
@@ -1,20 +1,16 @@
 package com.uid2.client;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Set;
+
 @Getter
+@AllArgsConstructor
 public class Site {
     private final int id;
 
     private final Set<String> domainOrAppNames;
-
-    public Site(int id, List<String> domainOrAppNames) {
-        this.id = id;
-        this.domainOrAppNames = new HashSet<>(domainOrAppNames);
-    }
 
     public boolean allowDomainOrAppName(String domainOrAppName) {
         // Using streams because HashSet's contains() is case sensitive

--- a/src/main/java/com/uid2/client/Site.java
+++ b/src/main/java/com/uid2/client/Site.java
@@ -1,16 +1,18 @@
 package com.uid2.client;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.util.Set;
 
-@Getter
-@AllArgsConstructor
 public class Site {
     private final int id;
 
     private final Set<String> domainOrAppNames;
+
+    public int getId() { return id;}
+
+    public Site(int id, Set<String> domainOrAppNames) {
+        this.id = id;
+        this.domainOrAppNames = domainOrAppNames;
+    }
 
     public boolean allowDomainOrAppName(String domainOrAppName) {
         // Using streams because HashSet's contains() is case sensitive

--- a/src/main/java/com/uid2/client/TokenHelper.java
+++ b/src/main/java/com/uid2/client/TokenHelper.java
@@ -15,7 +15,7 @@ class TokenHelper {
         this.uid2Helper = new Uid2Helper(base64SecretKey);
     }
 
-    DecryptionResponse decrypt(String token, Instant now, String domainNameFromBidRequest, ClientType clientType) {
+    DecryptionResponse decrypt(String token, Instant now, String domainOrAppNameFromBidRequest, ClientType clientType) {
         KeyContainer keyContainer = this.container.get();
         if (keyContainer == null) {
             return DecryptionResponse.makeError(DecryptionStatus.NOT_INITIALIZED);
@@ -26,7 +26,7 @@ class TokenHelper {
         }
 
         try {
-            return Uid2Encryption.decrypt(token, keyContainer, now, keyContainer.getIdentityScope(), domainNameFromBidRequest, clientType);
+            return Uid2Encryption.decrypt(token, keyContainer, now, keyContainer.getIdentityScope(), domainOrAppNameFromBidRequest, clientType);
         } catch (Exception e) {
             return DecryptionResponse.makeError(DecryptionStatus.INVALID_PAYLOAD);
         }

--- a/src/test/java/com/uid2/client/BidstreamClientTests.java
+++ b/src/test/java/com/uid2/client/BidstreamClientTests.java
@@ -206,16 +206,23 @@ public class BidstreamClientTests {
         );
     }
 
+    // These are the domain or app names associated with site SITE_ID, as defined by keyBidstreamResponse()
     @ParameterizedTest
     @CsvSource({
             "example.com, V2",
             "example.org, V2",
+            "com.123.Game.App.android, V2",
+            "123456789, V2",
+            "example.com, V3",
+            "example.org, V3",
+            "com.123.Game.App.android, V3",
+            "123456789, V3",
             "example.com, V4",
             "example.org, V4",
-            "example.com, V4",
-            "example.org, V4"
+            "com.123.Game.App.android, V4",
+            "123456789, V4"
     })
-    public void TokenIsCstgDerivedTest(String domainName, TokenVersionForTesting tokenVersion) throws Exception {
+    public void tokenIsCstgDerivedTest(String domainName, TokenVersionForTesting tokenVersion) throws Exception {
         refresh(keyBidstreamResponse(IdentityScope.UID2, MASTER_KEY, SITE_KEY));
         int privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
 
@@ -224,6 +231,104 @@ public class BidstreamClientTests {
         validateAdvertisingToken(advertisingToken, IdentityScope.UID2, IdentityType.Email, tokenVersion);
         DecryptionResponse res = bidstreamClient.decryptTokenIntoRawUid(advertisingToken, domainName);
         assertTrue(res.getIsClientSideGenerated());
+        assertTrue(res.isSuccess());
+        assertEquals(DecryptionStatus.SUCCESS, res.getStatus());
+        assertEquals(EXAMPLE_UID, res.getUid());
+    }
+
+    // These are the domain or app names associated with site SITE_ID but vary in capitalization, as defined by keyBidstreamResponse()
+    @ParameterizedTest
+    @CsvSource({
+            "Example.com, V2",
+            "Example.Org, V2",
+            "com.123.Game.App.android, V2",
+            "Example.com, V3",
+            "Example.Org, V3",
+            "com.123.Game.App.android, V3",
+            "Example.com, V4",
+            "Example.Org, V4",
+            "com.123.Game.App.android, V4",
+    })
+    public void domainOrAppNameCaseInSensitiveTest(String domainName, TokenVersionForTesting tokenVersion) throws Exception {
+        refresh(keyBidstreamResponse(IdentityScope.UID2, MASTER_KEY, SITE_KEY));
+        int privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
+
+        String advertisingToken = AdvertisingTokenBuilder.builder().withVersion(tokenVersion).withPrivacyBits(privacyBits).build();
+
+        validateAdvertisingToken(advertisingToken, IdentityScope.UID2, IdentityType.Email, tokenVersion);
+        DecryptionResponse res = bidstreamClient.decryptTokenIntoRawUid(advertisingToken, domainName);
+        assertTrue(res.getIsClientSideGenerated());
+        assertTrue(res.isSuccess());
+        assertEquals(DecryptionStatus.SUCCESS, res.getStatus());
+        assertEquals(EXAMPLE_UID, res.getUid());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ", V2",
+            "example.net, V2", // Domain associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "example.edu, V2", // Domain associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "com.123.Game.App.ios, V2", // App associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "123456780, V2", // App associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "foo.com, V2",     // Domain not associated with any site.
+            ", V3",
+            "example.net, V3", // Domain associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "example.edu, V3", // Domain associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "com.123.Game.App.ios, V3", // App associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "123456780, V3", // App associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "foo.com, V3",     // Domain not associated with any site.
+            ", V4",
+            "example.net, V4", // Domain associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "example.edu, V4", // Domain associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "com.123.Game.App.ios, V4", // App associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "123456780, V4", // App associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "foo.com, V4",     // Domain not associated with any site.
+    })
+    public void tokenIsCstgDerivedDomainOrAppNameFailTest(String domainName, TokenVersionForTesting tokenVersion) throws Exception {
+        refresh(keyBidstreamResponse(IdentityScope.UID2, MASTER_KEY, SITE_KEY));
+        int privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
+
+        String advertisingToken = AdvertisingTokenBuilder.builder().withVersion(tokenVersion).withPrivacyBits(privacyBits).build();
+
+        validateAdvertisingToken(advertisingToken, IdentityScope.UID2, IdentityType.Email, tokenVersion);
+        DecryptionResponse res = bidstreamClient.decryptTokenIntoRawUid(advertisingToken, domainName);
+        assertTrue(res.getIsClientSideGenerated());
+        assertFalse(res.isSuccess());
+        assertEquals(DecryptionStatus.DOMAIN_OR_APP_NAME_CHECK_FAILED, res.getStatus());
+        assertNull(res.getUid());
+    }
+
+    // Any domain or app name is OK, because the token is not client-side generated.
+    @ParameterizedTest
+    @CsvSource({
+            ", V2",
+            "example.net, V2", // Domain associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "example.edu, V2", // Domain associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "com.123.Game.App.ios, V2", // App associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "123456780, V2", // App associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "foo.com, V2",     // Domain not associated with any site.
+            ", V3",
+            "example.net, V3", // Domain associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "example.edu, V3", // Domain associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "com.123.Game.App.ios, V3", // App associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "123456780, V3", // App associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "foo.com, V3",     // Domain not associated with any site.
+            ", V4",
+            "example.net, V4", // Domain associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "example.edu, V4", // Domain associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "com.123.Game.App.ios, V4", // App associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "123456780, V4", // App associated with site SITE_ID2, as defined by keyBidstreamResponse().
+            "foo.com, V4",     // Domain not associated with any site.
+    })
+    public void tokenIsNotCstgDerivedDomainNameSuccessTest(String domainName, TokenVersionForTesting tokenVersion) throws Exception {
+        refresh(keyBidstreamResponse(IdentityScope.UID2, MASTER_KEY, SITE_KEY));
+        int privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(false).Build();
+
+        String advertisingToken = AdvertisingTokenBuilder.builder().withVersion(tokenVersion).withPrivacyBits(privacyBits).build();
+
+        validateAdvertisingToken(advertisingToken, IdentityScope.UID2, IdentityType.Email, tokenVersion);
+        DecryptionResponse res = bidstreamClient.decryptTokenIntoRawUid(advertisingToken, domainName);
+        assertFalse(res.getIsClientSideGenerated());
         assertTrue(res.isSuccess());
         assertEquals(DecryptionStatus.SUCCESS, res.getStatus());
         assertEquals(EXAMPLE_UID, res.getUid());
@@ -352,16 +457,19 @@ public class BidstreamClientTests {
         JsonArray domainNames1 = new JsonArray();
         domainNames1.add("example.com");
         domainNames1.add("example.org");
+        domainNames1.add("com.123.Game.App.android");
+        domainNames1.add("123456789");
         site1.add("domain_names", domainNames1);
         site1.addProperty("unexpected_domain_field", "123");
 
+
         JsonObject site2 = new JsonObject();
-        site1.addProperty("id", SITE_ID2);
+        site2.addProperty("id", SITE_ID2);
         JsonArray domainNames2 = new JsonArray();
         domainNames2.add("example.net");
         domainNames2.add("example.edu");
-        site1.add("domain_names", domainNames2);
-        site1.addProperty("unexpected_domain_field", "123");
+        site2.add("domain_names", domainNames2);
+        site2.addProperty("unexpected_domain_field", "123");
 
         JsonArray siteData = new JsonArray();
         siteData.add(site1);

--- a/src/test/java/com/uid2/client/BidstreamClientTests.java
+++ b/src/test/java/com/uid2/client/BidstreamClientTests.java
@@ -206,6 +206,21 @@ public class BidstreamClientTests {
         );
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"V2", "V3", "V4"})
+    public void userOptedOutTest(TokenVersionForTesting tokenVersion) throws Exception {
+        refresh(keyBidstreamResponse(IdentityScope.UID2, MASTER_KEY, SITE_KEY));
+        int privacyBits = PrivacyBitsBuilder.Builder().WithOptedOut(true).Build();
+
+        String advertisingToken = AdvertisingTokenBuilder.builder().withVersion(tokenVersion).withPrivacyBits(privacyBits).build();
+
+        validateAdvertisingToken(advertisingToken, IdentityScope.UID2, IdentityType.Email, tokenVersion);
+        DecryptionResponse res = bidstreamClient.decryptTokenIntoRawUid(advertisingToken, null);
+        assertFalse(res.isSuccess());
+        assertEquals(DecryptionStatus.SUCCESS, res.getStatus());
+        assertNull(res.getUid());
+    }
+
     // These are the domain or app names associated with site SITE_ID, as defined by keyBidstreamResponse()
     @ParameterizedTest
     @CsvSource({

--- a/src/test/java/com/uid2/client/BidstreamClientTests.java
+++ b/src/test/java/com/uid2/client/BidstreamClientTests.java
@@ -206,21 +206,6 @@ public class BidstreamClientTests {
         );
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"V2", "V3", "V4"})
-    public void userOptedOutTest(TokenVersionForTesting tokenVersion) throws Exception {
-        refresh(keyBidstreamResponse(IdentityScope.UID2, MASTER_KEY, SITE_KEY));
-        int privacyBits = PrivacyBitsBuilder.Builder().WithOptedOut(true).Build();
-
-        String advertisingToken = AdvertisingTokenBuilder.builder().withVersion(tokenVersion).withPrivacyBits(privacyBits).build();
-
-        validateAdvertisingToken(advertisingToken, IdentityScope.UID2, IdentityType.Email, tokenVersion);
-        DecryptionResponse res = bidstreamClient.decryptTokenIntoRawUid(advertisingToken, null);
-        assertFalse(res.isSuccess());
-        assertEquals(DecryptionStatus.SUCCESS, res.getStatus());
-        assertNull(res.getUid());
-    }
-
     // These are the domain or app names associated with site SITE_ID, as defined by keyBidstreamResponse()
     @ParameterizedTest
     @CsvSource({

--- a/src/test/java/com/uid2/client/BidstreamClientTests.java
+++ b/src/test/java/com/uid2/client/BidstreamClientTests.java
@@ -389,6 +389,13 @@ public class BidstreamClientTests {
 
         res = bidstreamClient.decryptTokenIntoRawUid(advertisingToken, null, expiry.minus(1, ChronoUnit.SECONDS));
         assertEquals(EXAMPLE_UID, res.getUid());
+
+        // case when domain / app name is present
+        int privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
+        String cstgAdvertisingToken = AdvertisingTokenBuilder.builder().withExpiry(expiry).withGenerated(generated)
+                .withPrivacyBits(privacyBits).build();
+        res = bidstreamClient.decryptTokenIntoRawUid(cstgAdvertisingToken, "example.com", expiry.minus(1, ChronoUnit.SECONDS));
+        assertTrue(res.isSuccess());
     }
 
     @ParameterizedTest

--- a/src/test/java/com/uid2/client/KeyParserTests.java
+++ b/src/test/java/com/uid2/client/KeyParserTests.java
@@ -97,6 +97,88 @@ public class KeyParserTests {
     }
 
     @Test
+    public void parseMissingSiteData() {
+        String json = "{ \"body\": {\n" +
+                "  \"keys\": [\n" +
+                "       {\n" +
+                "       \"id\": 3,\n" +
+                "       \"keyset_id\": 99999,\n" +
+                "       \"created\": 1609459200,\n" +
+                "       \"activates\": 1609459210,\n" +
+                "       \"expires\": 1893456000,\n" +
+                "       \"secret\": \"o8HsvkwJ5Ulnrd0uui3GpukpwDapj+JLqb7qfN/GJKo=\"\n" +
+                "          }\n" +
+                "      ]\n" +
+                "  }\n" +
+                "}";
+        KeyContainer keyContainer = parse(json);
+        boolean isAllowed = keyContainer.isDomainOrAppNameAllowedForSite(1, "example.com");
+        assertFalse(isAllowed);
+        assertNotNull(keyContainer.getKey(3));
+    }
+
+    @Test
+    public void parseEmptySiteData() {
+        String json = "{ \"body\": {\n" +
+                 "  \"keys\": [\n" +
+                 "       {\n" +
+                 "       \"id\": 3,\n" +
+                 "       \"keyset_id\": 99999,\n" +
+                 "       \"created\": 1609459200,\n" +
+                 "       \"activates\": 1609459210,\n" +
+                 "       \"expires\": 1893456000,\n" +
+                 "       \"secret\": \"o8HsvkwJ5Ulnrd0uui3GpukpwDapj+JLqb7qfN/GJKo=\"\n" +
+                 "          }\n" +
+                 "      ],\n" +
+                 "      \"site_data\": []\n" +
+                 "     }\n" +
+                 "}";
+        KeyContainer keyContainer = parse(json);
+        boolean isAllowed = keyContainer.isDomainOrAppNameAllowedForSite(1, "example.com");
+        assertFalse(isAllowed);
+        assertFalse(keyContainer.isDomainOrAppNameAllowedForSite(1,  null));
+        assertNotNull(keyContainer.getKey(3));
+    }
+
+    @Test
+    public void parseSiteDataSharingEndpoint() {
+        String json = "{\n" +
+                "        \"body\": {\n" +
+                "            \"keys\": [\n" +
+                "            {\n" +
+                "                \"id\": 3,\n" +
+                "                \"keyset_id\": 99999,\n" +
+                "                \"created\": 1609459200,\n" +
+                "                \"activates\": 1609459210,\n" +
+                "                \"expires\": 1893456000,\n" +
+                "                \"secret\": \"o8HsvkwJ5Ulnrd0uui3GpukpwDapj+JLqb7qfN/GJKo=\"\n" +
+                "            }\n" +
+                "        ],\n" +
+                "            \"site_data\": [\n" +
+                "            {\n" +
+                "                \"id\": 9,\n" +
+                "                \"domain_names\": [\"example.com\"]\n" +
+                "            },\n" +
+                "            {\n" +
+                "                \"id\": 100,\n" +
+                "                \"domain_names\": [\"example.org\", \"example.net\"]\n" +
+                "            }\n" +
+                "        ]\n" +
+                "    }\n" +
+                "}";
+        KeyContainer keyContainer = parse(json);
+        assertTrue(keyContainer.isDomainOrAppNameAllowedForSite(9, "example.com"));
+        assertFalse(keyContainer.isDomainOrAppNameAllowedForSite(9, "example.org"));
+        assertFalse(keyContainer.isDomainOrAppNameAllowedForSite(9, "example.net"));
+
+        assertFalse(keyContainer.isDomainOrAppNameAllowedForSite(100, "example.com"));
+        assertTrue(keyContainer.isDomainOrAppNameAllowedForSite(100, "example.org"));
+        assertTrue(keyContainer.isDomainOrAppNameAllowedForSite(100, "example.net"));
+
+        assertNotNull(keyContainer.getKey(3));
+    }
+
+    @Test
     public void parseWithNullTokenExpirySecondField() {
         String s = "{ \"body\": { " +
                 "\"caller_site_id\": 11, " +

--- a/src/test/java/com/uid2/client/SiteTests.java
+++ b/src/test/java/com/uid2/client/SiteTests.java
@@ -1,0 +1,50 @@
+package com.uid2.client;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+public class SiteTests {
+
+    private static Site site;
+
+    @BeforeAll
+    public static void setup() {
+        site = new Site(101, new HashSet<>(Arrays.asList(
+         "example.com",
+         "example.org",
+         "com.123.Game.App.android",
+         "123456789"
+        )));
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "example.com",
+            "example.org",
+            "com.123.Game.App.android",
+            "123456789",
+            "EXAMPLE.COM",
+            "com.123.game.app.android",
+        })
+    public void testAllowDomainOrAppNameSuccess(String domainOrAppName) {
+        Assertions.assertTrue(site.allowDomainOrAppName(domainOrAppName));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "*",
+            "example",
+            "example*",
+            "example.net"
+    })
+    public void testAllowDomainOrAppNameFailure(String domainOrAppName) {
+        Assertions.assertFalse(site.allowDomainOrAppName(domainOrAppName));
+    }
+}


### PR DESCRIPTION
- Domain name / App name check will be enforced while decrypting tokens by BidStreamClient if the tokens have been generated at Client Side
- Check will be skipped for
  - SharingClient
  - Legacy client (UID2Client)
  - Token generated at Server side
- Introducing lombok as a dependency